### PR TITLE
Added section Dependencies to README.MD to collect information on packag...

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ Dependencies
 There is only one dependency that is not included in the Python3.X
 Standard Library which must be installed.
 
-* (pySide http://qt-project.org/wiki/PySide) - pySide is used as the
+* [pySide](http://qt-project.org/wiki/PySide) - pySide is used as the
   user interface framework and must be installed on your system for
-  pyTalkmanager to run. pySide can be downloaded from (here
-  http://qt-project.org/wiki/Category:LanguageBindings::PySide::Downloads).
+  pyTalkmanager to run. pySide can be downloaded from [here]
+  (http://qt-project.org/wiki/Category:LanguageBindings::PySide::Downloads).
 
 Note
 ====


### PR DESCRIPTION
...es that pyTalkManager depends on to aid the end user in installing pyTalkManager from source.
