### PR TITLE
Fixed bug caused by commit f8fc9ec498 related to Issue #53.

### DIFF
--- a/main.py
+++ b/main.py
@@ -140,7 +140,7 @@ class CongregationWindow(QtGui.QDialog, gui.CongregationWindow.Ui_CongregationWi
         self.show_edit.show()
         self.show_edit.setWindowTitle("Edit Congregation")
         self.show_edit.button_add.setText('Save')  # Renamed 'Add' button to 'Save'
-        self.show_edit.button_add.clicked.connect(lambda: self.load_congregation_data(selection[0]))
+        self.show_edit.button_add.clicked.connect(lambda: self.load_congregation_data(all_congregations[selection][0]))
 
         # Fill all of the fields with the values from the database.
         # All the fields must be converted to string.


### PR DESCRIPTION
**selection** is the index of the congregation
  list. **all_congregations** is all the rows for the Congregation table
  in a tuple in the same order as displayed in the list. The correct way
  to pass the row id is **all_congregations[selection][0]**.
