### PR TITLE
Update cong. list after deletion. Bug #82

### DIFF
--- a/pyTalkManager/main.py
+++ b/pyTalkManager/main.py
@@ -234,6 +234,7 @@ class CongregationWindow(QtGui.QDialog,
         id = self.sorted_list[selection][0]
 
         DB.modify_item(None, 'Congregation', ['visibility'], ['False'], id)
+        self.populate_table()  # Update the cong. list after deletion
 
 
 class AddCongregationWindow(QtGui.QDialog,


### PR DESCRIPTION
The congregation list was not being updated after a deletion
occurred. This commit fixes that by calling the function that updates the
congregation list after an item has been deleted.
